### PR TITLE
Adding x11 support to fuzzwatch docker runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,22 @@ Scripts for building and running example targets are included:
 ## Installing
 
 There shouldn't be many non-Python dependencies of Fuzzwatch itself, but a
-Dockerfile is included to show a clean Ubuntu build. You’ll have to run
-Fuzzwatch outside of a docker container to see the GUI (unless you do X window
-forwarding or something similar), but you can pass the switch `--disable_gui` to
-Manul if you want to test that everything besides the GUI works.
+Dockerfile is included to show a clean Ubuntu build.
 
+If you want to run Fuzzwatch from inside the container, you'll need to pass an
+X11 unix socket into the container and disable access control. There are other
+access mechanisms in the xhost manpage, but for compatibility and ease-of-use,
+we disable it in this example.
+
+```bash
+xhost +
+docker build -t mechanicalnull/fuzzwatch .
+docker run -it --rm \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -e DISPLAY=unix$DISPLAY \
+    mechanicalnull/fuzzwatch ./run_fuzzwatch_fuzztest.sh
+xhost -
+```
 ## About Fuzzwatch
 
 Fuzzwatch is strictly for demonstration/learning purposes. Fuzzers don't


### PR DESCRIPTION
Hey @mechanicalnull !

I added a quick series of commands to the README.md file which will allow you to run from inside a docker container. There's one caveat in this version: The X11 unix socket has no access control, meaning anyone can spawn an x11 program on the user's X11 server using only `DISPLAY=:$DISPLAYNUM_OF_USER xclock`.

A solution would be to run `xhost si:localuser:$(whoami)` instead and then run the container as that user by passing `-u $(id -u):$(id -g)` to the `docker run` command. I tried this, but there's some permissions issues with the /src/fuzztest directory. I am happy to fix these later today if this is a pattern you intend to support, but I wanted to send along before I went to the office today.